### PR TITLE
feat: 예외 필터 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
     implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     compileOnly("org.projectlombok:lombok")

--- a/src/main/kotlin/com/jordyma/blink/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/jordyma/blink/global/config/SecurityConfig.kt
@@ -1,0 +1,32 @@
+package com.jordyma.blink.global.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.authentication.AuthenticationManager
+import org.springframework.security.config.Customizer
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
+
+@Configuration
+class SecurityConfig() {
+
+
+    val permitAllUrls = arrayOf<String>(
+        "/swagger-ui/**",
+        "/swagger-resources/**",
+        "/location/**",
+        "/api/auth/kakao-login",
+        "/error",
+        "/test")
+
+    @Bean
+    fun filterChain(http: HttpSecurity) = http
+        .httpBasic { it.disable() }
+        .formLogin { it.disable() }
+        .cors(Customizer.withDefaults())
+        .csrf { it.disable()}
+        .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
+        .authorizeHttpRequests { it.requestMatchers(*permitAllUrls).permitAll().anyRequest().authenticated() }
+        .build()
+}

--- a/src/main/kotlin/com/jordyma/blink/global/exception/ApplicationException.kt
+++ b/src/main/kotlin/com/jordyma/blink/global/exception/ApplicationException.kt
@@ -1,0 +1,4 @@
+package com.jordyma.blink.global.exception
+
+class ApplicationException(val code: ErrorCode, override val message: String, val throwable: Throwable?): RuntimeException(message) {
+}

--- a/src/main/kotlin/com/jordyma/blink/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/jordyma/blink/global/exception/ErrorCode.kt
@@ -1,0 +1,7 @@
+package com.jordyma.blink.global.exception
+
+import org.springframework.http.HttpStatus
+
+enum class ErrorCode(val errorCode: String, val statusCode: HttpStatus) {
+    UNAUTHORIZED("A000", HttpStatus.UNAUTHORIZED),
+}

--- a/src/main/kotlin/com/jordyma/blink/global/exception/ErrorResponse.kt
+++ b/src/main/kotlin/com/jordyma/blink/global/exception/ErrorResponse.kt
@@ -1,0 +1,13 @@
+package com.jordyma.blink.global.exception
+
+data class ErrorResponse (
+    val code: String,
+    val message: String,
+    val detail: String?,
+) {
+    companion object {
+        fun of(code: ErrorCode, message: String, detail: String?): ErrorResponse {
+            return ErrorResponse(code.name, message, detail)
+        }
+    }
+}

--- a/src/main/kotlin/com/jordyma/blink/global/handler/ApplicationExceptionHandler.kt
+++ b/src/main/kotlin/com/jordyma/blink/global/handler/ApplicationExceptionHandler.kt
@@ -1,0 +1,26 @@
+package com.jordyma.blink.global.handler
+
+import com.jordyma.blink.global.exception.ApplicationException
+import com.jordyma.blink.global.exception.ErrorResponse
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+class ApplicationExceptionHandler {
+
+    @ExceptionHandler(ApplicationException::class)
+    fun handleCommonException(e: ApplicationException): ResponseEntity<ErrorResponse> {
+        val errorResponse = ErrorResponse(
+            code = e.code.errorCode,
+            message = e.message,
+            detail = e.throwable?.message
+        )
+        println("ApplicationExceptionHandler.handleCommonException: $errorResponse")
+        return ResponseEntity(errorResponse, e.code.statusCode)
+    }
+}

--- a/src/main/kotlin/com/jordyma/blink/test/TestController.kt
+++ b/src/main/kotlin/com/jordyma/blink/test/TestController.kt
@@ -1,4 +1,0 @@
-package com.jordyma.blink.test
-
-class TestController {
-}

--- a/src/main/kotlin/com/jordyma/blink/test/TestController.kt
+++ b/src/main/kotlin/com/jordyma/blink/test/TestController.kt
@@ -1,0 +1,4 @@
+package com.jordyma.blink.test
+
+class TestController {
+}


### PR DESCRIPTION
## 서비스 로직 예외 정의
* ApplicationException 추가([링크](https://github.com/JORDYMA-Link/Link-Server/pull/4/files#diff-1641963507515edee8eb382495af6c8fbfc36ca9998796d16de06bb36a8fb410))
* 사용 예시
```
throw ApplicationException(ErrorCode.UNAUTHORIZED, '전달하고 싶은 에러 메세지', Throwable())
// 단, Throwable은 optional. 별도의 에러를 catch 해서 ApplicationException으로 던질 때 사용
```
* 서비스 로직에서 발생시켜야하는 예외는 ApplicationException을 사용

## 에러코드 정의
* ErrorCode Enum 추가([링크](https://github.com/JORDYMA-Link/Link-Server/pull/4/files#diff-4af2ebb00198167c7c70a9da3b2bbbbe15d441b1313342f7e7fc8bb694b928c6))
* 새로운 에러가 필요할때마다 새로 추가해서 사용해도 됨. 원하는 코드 원하는대로 추가 가능
* 클라이언트에 던질 HttpCode와 같이 정의하면됨

## 서비스 로직 exception handler 추가
* ApplicationException을 catch하는 핸들러 추가([링크](https://github.com/JORDYMA-Link/Link-Server/pull/4/files#diff-2373b299a89ee6b4dade81a99035183660f38b41a31149a213d525b8b832a6f9))