### PR TITLE
feat: sqs 설정 및 요약 요청 클라이언트 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,12 @@ configurations {
     }
 }
 
+dependencyManagement {
+    imports {
+        mavenBom("io.awspring.cloud:spring-cloud-aws-dependencies:3.0.1")
+    }
+}
+
 repositories {
     mavenCentral()
 }
@@ -43,6 +49,8 @@ dependencies {
     implementation("org.springdoc:springdoc-openapi-ui:1.7.0")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.2.2")
+
+    implementation("io.awspring.cloud:spring-cloud-aws-starter-sqs")
 
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     runtimeOnly("org.postgresql:postgresql")

--- a/src/main/kotlin/com/jordyma/blink/feed_summarize_requester/sender/FeedSummarizeMessageSender.kt
+++ b/src/main/kotlin/com/jordyma/blink/feed_summarize_requester/sender/FeedSummarizeMessageSender.kt
@@ -1,0 +1,9 @@
+package com.jordyma.blink.feed_summarize_requester.sender
+
+import com.jordyma.blink.feed_summarize_requester.sender.dto.FeedSummarizeMessage
+import io.awspring.cloud.sqs.operations.SendResult
+
+interface FeedSummarizeMessageSender {
+
+    fun send(message: FeedSummarizeMessage): SendResult<FeedSummarizeMessage>
+}

--- a/src/main/kotlin/com/jordyma/blink/feed_summarize_requester/sender/FeedSummarizeMessageSenderImpl.kt
+++ b/src/main/kotlin/com/jordyma/blink/feed_summarize_requester/sender/FeedSummarizeMessageSenderImpl.kt
@@ -1,0 +1,20 @@
+package com.jordyma.blink.feed_summarize_requester.sender
+
+import com.jordyma.blink.feed_summarize_requester.sender.dto.FeedSummarizeMessage
+import io.awspring.cloud.sqs.operations.SendResult
+import io.awspring.cloud.sqs.operations.SqsTemplate
+import org.springframework.beans.factory.annotation.Value
+
+class FeedSummarizeMessageSenderImpl(
+    @Value("\${jwt.secret}") private val queueName: String,
+    private val sqsTemplate: SqsTemplate,
+): FeedSummarizeMessageSender {
+
+    override fun send(message: FeedSummarizeMessage): SendResult<FeedSummarizeMessage> {
+        return sqsTemplate.send { to ->
+            to
+                .queue(queueName)
+                .payload(message)
+        }
+    }
+}

--- a/src/main/kotlin/com/jordyma/blink/feed_summarize_requester/sender/dto/FeedSummarizeMessage.kt
+++ b/src/main/kotlin/com/jordyma/blink/feed_summarize_requester/sender/dto/FeedSummarizeMessage.kt
@@ -1,0 +1,7 @@
+package com.jordyma.blink.feed_summarize_requester.sender.dto
+
+data class FeedSummarizeMessage (
+    // TODO 메세지 형식에 따라 변경가능 지금은 임시로 넣어둔 것.
+    val feedUrl: String,
+    val feedId: String
+)

--- a/src/main/kotlin/com/jordyma/blink/global/config/AwsSQSConfig.kt
+++ b/src/main/kotlin/com/jordyma/blink/global/config/AwsSQSConfig.kt
@@ -1,0 +1,47 @@
+package com.jordyma.blink.global.config
+
+import io.awspring.cloud.sqs.operations.SqsTemplate
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import software.amazon.awssdk.auth.credentials.AwsCredentials
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.sqs.SqsAsyncClient
+
+
+@Configuration
+class AwsSQSConfig(
+    @Value("\${spring.cloud.aws.credentials.access-key}")
+    private val awsAccessKey: String,
+    @Value("\${spring.cloud.aws.credentials.secret-key}")
+    private val awsSecretKey: String,
+    @Value("\${spring.cloud.aws.region.static}")
+    private val region: String,
+) {
+    /**
+     * AWS SQS 클라이언트
+     */
+    @Bean
+    fun sqsAsyncClient(): SqsAsyncClient {
+        return SqsAsyncClient.builder()
+            .credentialsProvider {
+                object : AwsCredentials {
+                    override fun accessKeyId(): String {
+                        return awsAccessKey
+                    }
+
+                    override fun secretAccessKey(): String {
+                        return awsSecretKey
+                    }
+                }
+            }
+            .region(Region.of(region))
+            .build()
+    }
+
+    // 메세지 발송을 위한 SQS 템플릿 설정
+    @Bean
+    fun sqsTemplate(): SqsTemplate {
+        return SqsTemplate.newTemplate(sqsAsyncClient())
+    }
+}


### PR DESCRIPTION
### sqs 설정 추가
* 링크 저장 요청을 MQ에 적재하기 위한 config 및 sqs클라이언트 추가
* 링크 저장 api가 아직 머지되지 않은것으로 파악되어, api 수정까지는 해두진 않은 상태.
* 링크 저장 api가 머지되면 로직 자체는 워커로 이전한 후, [FeedSummarizeMessageSender.send](https://github.com/JORDYMA-Link/Link-Server/pull/25/files#diff-c32f5dba67f5a1f6035b90370dbaf476002ed4d02e65ec8c8495291aea00c7ceR8)를 통해 MQ에 메세지를 적재하도록 수정이되면 좋을것 같습니다.