### PR TITLE
feat: 로그아웃, 탈퇴하기 api

### DIFF
--- a/src/main/kotlin/com/jordyma/blink/auth/controller/AuthController.kt
+++ b/src/main/kotlin/com/jordyma/blink/auth/controller/AuthController.kt
@@ -1,7 +1,7 @@
 package com.jordyma.blink.auth.controller
 import com.jordyma.blink.auth.dto.State
-import com.jordyma.blink.auth.dto.request.KakaoLoginRequestDto
 import com.jordyma.blink.auth.dto.request.AppleLoginRequestDto
+import com.jordyma.blink.auth.dto.request.KakaoLoginRequestDto
 import com.jordyma.blink.auth.dto.response.TokenResponseDto
 import com.jordyma.blink.auth.service.AuthService
 import com.jordyma.blink.global.exception.ApplicationException
@@ -12,16 +12,13 @@ import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.tags.Tag
 import kotlinx.serialization.json.*
 import lombok.RequiredArgsConstructor
-import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.*
-import org.springframework.web.util.UriComponentsBuilder
-import java.net.URI
-import java.net.URL
+import java.time.LocalDateTime
 import java.util.*
 
 
@@ -88,4 +85,14 @@ class AuthController(
         headers.location = uri.toUri()
         return ResponseEntity<Void>(headers, HttpStatus.FOUND)
     }
+
+    @PostMapping("/logout")
+    @Operation(summary = "로그아웃", description = "refresh token으로만 요청 가능, 로그아웃 처리 시 db에 저장된 refresh token 만료 처리")
+    fun logout(
+        @RequestHeader(value = "Authorization") refreshToken: String
+    ): ResponseEntity<String> {
+        authService.logout(refreshToken)
+        return ResponseEntity.ok().body("로그아웃이 완료되었습니다.")
+    }
+
 }

--- a/src/main/kotlin/com/jordyma/blink/auth/controller/AuthController.kt
+++ b/src/main/kotlin/com/jordyma/blink/auth/controller/AuthController.kt
@@ -3,6 +3,7 @@ import com.jordyma.blink.auth.dto.State
 import com.jordyma.blink.auth.dto.request.AppleLoginRequestDto
 import com.jordyma.blink.auth.dto.request.KakaoLoginRequestDto
 import com.jordyma.blink.auth.dto.response.TokenResponseDto
+import com.jordyma.blink.auth.jwt.user_account.UserAccount
 import com.jordyma.blink.auth.service.AuthService
 import com.jordyma.blink.global.exception.ApplicationException
 import com.jordyma.blink.global.exception.ErrorCode
@@ -16,6 +17,7 @@ import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.*
 import java.time.LocalDateTime
@@ -95,4 +97,12 @@ class AuthController(
         return ResponseEntity.ok().body("로그아웃이 완료되었습니다.")
     }
 
+    @PostMapping("/signout")
+    @Operation(summary = "탈퇴하기", description = "탈퇴 처리 시 refresh token 만료 처리")
+    fun logout(
+        @AuthenticationPrincipal userAccount: UserAccount,
+    ): ResponseEntity<String> {
+        authService.signout(userAccount)
+        return ResponseEntity.ok().body("탈퇴가 완료되었습니다.")
+    }
 }

--- a/src/main/kotlin/com/jordyma/blink/global/Interceptor/AuthInterceptor.kt
+++ b/src/main/kotlin/com/jordyma/blink/global/Interceptor/AuthInterceptor.kt
@@ -1,0 +1,38 @@
+package com.jordyma.blink.global.Interceptor
+
+import com.jordyma.blink.auth.jwt.user_account.UserAccount
+import com.jordyma.blink.global.exception.ApplicationException
+import com.jordyma.blink.global.exception.ErrorCode
+import com.jordyma.blink.user.service.UserService
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Component
+import org.springframework.web.servlet.HandlerInterceptor
+
+
+@Component
+class AuthInterceptor(
+    private val userService: UserService
+) : HandlerInterceptor {
+
+    override fun preHandle(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        handler: Any
+    ): Boolean {
+        val authentication = SecurityContextHolder.getContext().authentication
+
+        if (authentication != null && authentication.isAuthenticated) {
+            val userAccount = authentication.principal as UserAccount
+
+            // 탈퇴한 유저인지 확인
+            if (userService.isDeletedUser(userAccount)) {
+                throw ApplicationException(ErrorCode.USER_SIGNED_OUT, "탈퇴한 유저입니다.")
+                return false
+            }
+        }
+
+        return true
+    }
+}

--- a/src/main/kotlin/com/jordyma/blink/global/config/WebConfig.kt
+++ b/src/main/kotlin/com/jordyma/blink/global/config/WebConfig.kt
@@ -1,0 +1,19 @@
+package com.jordyma.blink.global.config
+
+import com.jordyma.blink.global.Interceptor.AuthInterceptor
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+
+@Configuration
+class WebConfig(
+    private val authInterceptor: AuthInterceptor,
+) : WebMvcConfigurer {
+
+    override fun addInterceptors(registry: InterceptorRegistry) {
+        registry.addInterceptor(authInterceptor)
+            .addPathPatterns("/api/**")
+            .excludePathPatterns("/auth/**")
+    }
+}

--- a/src/main/kotlin/com/jordyma/blink/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/jordyma/blink/global/exception/ErrorCode.kt
@@ -24,6 +24,7 @@ enum class ErrorCode(val errorCode: String, val statusCode: HttpStatus) {
 
     // User
     USER_NOT_FOUND("U000", HttpStatus.NOT_FOUND),
+    USER_SIGNED_OUT("U001", HttpStatus.NOT_FOUND),
 
     // Folder
     NOT_CREATED("F000", HttpStatus.INTERNAL_SERVER_ERROR),

--- a/src/main/kotlin/com/jordyma/blink/user/entity/User.kt
+++ b/src/main/kotlin/com/jordyma/blink/user/entity/User.kt
@@ -2,6 +2,7 @@ package com.jordyma.blink.user.entity
 
 import com.jordyma.blink.global.entity.BaseTimeEntity
 import jakarta.persistence.*
+import java.time.LocalDateTime
 
 @Entity(name = "user")
 class User(
@@ -26,5 +27,9 @@ class User(
 
     fun updateNickname(nickname: String) {
         this.nickname = nickname
+    }
+
+    fun updateDeletedAt(){
+        this.deletedAt = LocalDateTime.now()
     }
 }

--- a/src/main/kotlin/com/jordyma/blink/user/service/UserService.kt
+++ b/src/main/kotlin/com/jordyma/blink/user/service/UserService.kt
@@ -43,4 +43,11 @@ class UserService (
             nickName = user.nickname
         )
     }
+
+    @Transactional
+    fun isDeletedUser(userAccount: UserAccount): Boolean {
+        val user = userRepository.findById(userAccount.userId)
+            .orElseThrow { throw ApplicationException(ErrorCode.USER_NOT_FOUND, "없는 유저입니다.") }
+        return user.deletedAt != null
+    }
 }

--- a/src/main/kotlin/com/jordyma/blink/user_refresh_token/entity/UserRefreshToken.kt
+++ b/src/main/kotlin/com/jordyma/blink/user_refresh_token/entity/UserRefreshToken.kt
@@ -1,36 +1,45 @@
 package com.jordyma.blink.user_refresh_token.entity
 
+import com.jordyma.blink.global.entity.BaseTimeEntity
 import com.jordyma.blink.user.entity.User
 import jakarta.persistence.*
-import lombok.AccessLevel
-import lombok.Getter
-import lombok.NoArgsConstructor
+import java.time.LocalDateTime
 
 @Entity
-@Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-class UserRefreshToken {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+class UserRefreshToken(
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id")
-    private var id: Long? = null
+    val id: Long? = null,
 
     @Column(name = "refresh_token", columnDefinition = "VARCHAR(500)")
-    private var refreshToken: String? = null
+    var refreshToken: String? = null,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
-    private var user: User? = null
+    var user: User? = null,
+
+    @Column(name = "token_expiration_time", columnDefinition = "DATETIME")
+    var tokenExpirationTime: LocalDateTime? = null,
+
+): BaseTimeEntity(){
 
     fun updateRefreshToken(refreshToken: String?) {
         this.refreshToken = refreshToken
     }
 
+    fun expire(now: LocalDateTime) {
+        if (tokenExpirationTime!!.isAfter(now)) {
+            this.tokenExpirationTime = now
+        }
+    }
+
     companion object {
-        fun of(refreshToken: String?, user: User?): UserRefreshToken {
+        fun of(refreshToken: String?, user: User?, expirationTime: LocalDateTime): UserRefreshToken {
             val userRefreshToken = UserRefreshToken()
             userRefreshToken.refreshToken = refreshToken
             userRefreshToken.user = user
+            userRefreshToken.tokenExpirationTime = expirationTime
 
             return userRefreshToken
         }

--- a/src/main/kotlin/com/jordyma/blink/user_refresh_token/repository/UserRefreshTokenRepository.kt
+++ b/src/main/kotlin/com/jordyma/blink/user_refresh_token/repository/UserRefreshTokenRepository.kt
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface UserRefreshTokenRepository : JpaRepository<UserRefreshToken?, Long?> {
     fun findByRefreshToken(refreshToken: String?): UserRefreshToken?
+    fun findByUserId(id: Long): UserRefreshToken
 }


### PR DESCRIPTION
- 로그아웃 api - 해당 유저의 refreshToken 만료
     - UserRefreshToken에 만료시간 칼럼 추가하고, refreshToken 생성할 때 db에 만료시간도 같이 저장되도록 수정했습니다.
     - UserRefreshToken 생성자 추가
- 탈퇴하기 api - 해당 유저 deletedAt 업데이트, refreshToken 만료
     - /api 경로의 인터셉터를 추가해서 탈퇴한 유저의 요청인지 검사하도록 구현했습니다. 