### PR TITLE
Fix/platform: 예외 링크 관리 및 요약 실패 처리 개선

### DIFF
--- a/blink-api/src/main/kotlin/com/jordyma/blink/feed/controller/FeedSummarizeController.kt
+++ b/blink-api/src/main/kotlin/com/jordyma/blink/feed/controller/FeedSummarizeController.kt
@@ -38,11 +38,10 @@ class FeedSummarizeController(
         val summarizeMessage = FeedSummarizeMessage(requestDto.link, feed.id, userAccount.userId, feed.originUrl, userName)
 
         if (feedSummarizeService.isInvalidLink(requestDto.link)){
-            logger().info(">>>>> EXCEPTION : Try to summarize invalid link: ${requestDto.link}")
+            logger().info(">>>>> FAILED : Try to summarize invalid link: ${requestDto.link}")
             feedService.createFailed(userAccount, feed.id)
             return ResponseEntity.ok(FeedIdResponseDto(feedId = feed.id))
         }
-
 
         // worker 요청 전송
         // feedSummarizeMessageSender.send(summarizeMessage)

--- a/blink-api/src/main/kotlin/com/jordyma/blink/feed/controller/FeedSummarizeController.kt
+++ b/blink-api/src/main/kotlin/com/jordyma/blink/feed/controller/FeedSummarizeController.kt
@@ -10,6 +10,7 @@ import com.jordyma.blink.feed.dto.response.ProcessingListDto
 import com.jordyma.blink.feed.service.FeedService
 import com.jordyma.blink.feed.service.FeedSummarizeService
 import com.jordyma.blink.feed_summarize_requester.sender.dto.FeedSummarizeMessage
+import com.jordyma.blink.logger
 import com.jordyma.blink.user.service.UserService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
@@ -35,6 +36,13 @@ class FeedSummarizeController(
         val feed = feedService.makeFeedFirst(userAccount, requestDto.link)
         val userName = userService.getProfile(userAccount).nickName
         val summarizeMessage = FeedSummarizeMessage(requestDto.link, feed.id, userAccount.userId, feed.originUrl, userName)
+
+        if (feedSummarizeService.isInvalidLink(requestDto.link)){
+            logger().info(">>>>> EXCEPTION : Try to summarize invalid link: ${requestDto.link}")
+            feedService.createFailed(userAccount, feed.id)
+            return ResponseEntity.ok(FeedIdResponseDto(feedId = feed.id))
+        }
+
 
         // worker 요청 전송
         // feedSummarizeMessageSender.send(summarizeMessage)

--- a/blink-api/src/main/kotlin/com/jordyma/blink/feed/service/FeedService.kt
+++ b/blink-api/src/main/kotlin/com/jordyma/blink/feed/service/FeedService.kt
@@ -504,7 +504,7 @@ class FeedService(
         val failedFolder = folderService.getFailed(userAccount.userId)
         val feed: Feed = findFeedOrElseThrow(feedId)
         feed.update(failedFolder, Status.FAILED)
-        feedRepository.save(feed)
+        folderService.createFeedFolder(userAccount.userId, feedId, failedFolder.name)
     }
 
     @Transactional

--- a/blink-api/src/main/kotlin/com/jordyma/blink/feed/service/FeedService.kt
+++ b/blink-api/src/main/kotlin/com/jordyma/blink/feed/service/FeedService.kt
@@ -500,17 +500,10 @@ class FeedService(
 
     // 요약 실패 피드 생성
     @Transactional
-    fun createFailed(userAccount: UserAccount, link: String) {
-        val user = findUserOrElseThrow(userAccount.userId)
+    fun createFailed(userAccount: UserAccount, feedId: Long) {
         val failedFolder = folderService.getFailed(userAccount.userId)
-        val feed = Feed(
-            folder = failedFolder,
-            originUrl = link,
-            summary = "",
-            title = "",
-            platform = "",
-            status = Status.FAILED,
-        )
+        val feed: Feed = findFeedOrElseThrow(feedId)
+        feed.update(failedFolder, Status.FAILED)
         feedRepository.save(feed)
     }
 

--- a/blink-api/src/main/kotlin/com/jordyma/blink/feed/service/FeedSummarizeService.kt
+++ b/blink-api/src/main/kotlin/com/jordyma/blink/feed/service/FeedSummarizeService.kt
@@ -89,7 +89,12 @@ class FeedSummarizeService(
     }
 
     fun isInvalidLink(link: String): Boolean {
-        return cachedInvalidLinks.contains(link)
+        for (invalidLink in cachedInvalidLinks){
+            if (link.contains(invalidLink)){
+                return true
+            }
+        }
+        return false
     }
 
 }

--- a/blink-api/src/main/kotlin/com/jordyma/blink/feed/service/FeedSummarizeService.kt
+++ b/blink-api/src/main/kotlin/com/jordyma/blink/feed/service/FeedSummarizeService.kt
@@ -1,5 +1,7 @@
 package com.jordyma.blink.feed.service
 
+import com.jordyma.blink.common.system.CommonParameterCode.EXCEPTION_LINK_PARAM_CODE
+import com.jordyma.blink.common.system.CommonParameterRepository
 import com.jordyma.blink.fcm.service.FcmService
 import com.jordyma.blink.feed.domain.FeedRepository
 import com.jordyma.blink.feed.domain.Source
@@ -14,10 +16,12 @@ import com.jordyma.blink.global.util.HtmlParserByJsoup
 import com.jordyma.blink.infra.gemini.GeminiService
 import com.jordyma.blink.logger
 import com.jordyma.blink.user.UserRepository
+import jakarta.annotation.PostConstruct
 import org.springframework.stereotype.Service
 
 @Service
 class FeedSummarizeService(
+    private val commonParamRepository: CommonParameterRepository,
     private val feedRepository: FeedRepository,
     private val folderRepository: FolderRepository,
     private val userRepository: UserRepository,
@@ -27,6 +31,7 @@ class FeedSummarizeService(
     private val feedService: FeedService,
     private val fcmService: FcmService,
 ){
+    private lateinit var cachedInvalidLinks: List<String>
 
     fun summarizeFeed(payload: FeedSummarizeMessage): PromptResponse? {
         val userId = payload.userId
@@ -75,6 +80,16 @@ class FeedSummarizeService(
         }
         // TODO: exception 되돌리기
         return null
+    }
+
+    @PostConstruct
+    fun loadInvalidLinks() {
+        cachedInvalidLinks = commonParamRepository.findByParamCode(EXCEPTION_LINK_PARAM_CODE).map { it.paramValue }
+        logger().info(">>>>> cachedInvalidLinks: $cachedInvalidLinks")
+    }
+
+    fun isInvalidLink(link: String): Boolean {
+        return cachedInvalidLinks.contains(link)
     }
 
 }

--- a/blink-api/src/main/kotlin/com/jordyma/blink/feed/service/FeedSummarizeServiceImpl.kt
+++ b/blink-api/src/main/kotlin/com/jordyma/blink/feed/service/FeedSummarizeServiceImpl.kt
@@ -20,14 +20,14 @@ import org.springframework.transaction.annotation.Transactional
 
 @Service
 class FeedSummarizeServiceImpl(
-    private val commonParamRepository: CommonParameterRepository,
+    //private val commonParamRepository: CommonParameterRepository,
     private val feedRepository: FeedRepository,
     private val folderService: FolderService,
     private val recommendRepository: RecommendRepository,
     private val keywordService: KeywordService,
 ) : FeedSummarizeService {
 
-    private lateinit var cachedInvalidLinks: List<String>
+    //private lateinit var cachedInvalidLinks: List<String>
 
     @Transactional
     override fun updateSummarizedFeed(
@@ -105,13 +105,13 @@ class FeedSummarizeServiceImpl(
         const val SUMMARY_COMPLETED = "링크 요약이 완료되었어요."
     }
 
-    @PostConstruct
-    fun loadInvalidLinks() {
-        cachedInvalidLinks = commonParamRepository.findByParamCode(EXCEPTION_LINK_PARAM_CODE).map { it.paramValue }
-        logger().info(">>>>> cachedInvalidLinks: $cachedInvalidLinks")
-    }
-
-    fun isInvalidLink(link: String): Boolean {
-        return cachedInvalidLinks.contains(link)
-    }
+//    @PostConstruct
+//    fun loadInvalidLinks() {
+//        cachedInvalidLinks = commonParamRepository.findByParamCode(EXCEPTION_LINK_PARAM_CODE).map { it.paramValue }
+//        logger().info(">>>>> cachedInvalidLinks: $cachedInvalidLinks")
+//    }
+//
+//    fun isInvalidLink(link: String): Boolean {
+//        return cachedInvalidLinks.contains(link)
+//    }
 }

--- a/blink-api/src/main/kotlin/com/jordyma/blink/feed/service/FeedSummarizeServiceImpl.kt
+++ b/blink-api/src/main/kotlin/com/jordyma/blink/feed/service/FeedSummarizeServiceImpl.kt
@@ -1,5 +1,7 @@
 package com.jordyma.blink.feed.service
 
+import com.jordyma.blink.common.system.CommonParameterCode.EXCEPTION_LINK_PARAM_CODE
+import com.jordyma.blink.common.system.CommonParameterRepository
 import com.jordyma.blink.feed.domain.Feed
 import com.jordyma.blink.feed.domain.FeedRepository
 import com.jordyma.blink.feed.domain.Source
@@ -17,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional
 
 @Service
 class FeedSummarizeServiceImpl(
+    private val commonParamRepository: CommonParameterRepository,
     private val feedRepository: FeedRepository,
     private val folderService: FolderService,
     private val recommendRepository: RecommendRepository,
@@ -97,5 +100,12 @@ class FeedSummarizeServiceImpl(
 
     companion object{
         const val SUMMARY_COMPLETED = "링크 요약이 완료되었어요."
+    }
+
+    fun isInvalidLink(link: String): Boolean {
+        val invalidLinks = commonParamRepository.findByParamCode(EXCEPTION_LINK_PARAM_CODE)
+            .map { it.paramValue }
+
+        return invalidLinks.contains(link)
     }
 }

--- a/blink-api/src/main/kotlin/com/jordyma/blink/feed/service/FeedSummarizeServiceImpl.kt
+++ b/blink-api/src/main/kotlin/com/jordyma/blink/feed/service/FeedSummarizeServiceImpl.kt
@@ -27,6 +27,8 @@ class FeedSummarizeServiceImpl(
     private val keywordService: KeywordService,
 ) : FeedSummarizeService {
 
+    private lateinit var cachedInvalidLinks: List<String>
+
     @Transactional
     override fun updateSummarizedFeed(
         content: PromptResponse,
@@ -103,11 +105,13 @@ class FeedSummarizeServiceImpl(
         const val SUMMARY_COMPLETED = "링크 요약이 완료되었어요."
     }
 
-    @PostConstruct // DB 데이터 메모리에 미리 로드해 캐싱
-    fun isInvalidLink(link: String): Boolean {
-        val invalidLinks = commonParamRepository.findByParamCode(EXCEPTION_LINK_PARAM_CODE)
-            .map { it.paramValue }
+    @PostConstruct
+    fun loadInvalidLinks() {
+        cachedInvalidLinks = commonParamRepository.findByParamCode(EXCEPTION_LINK_PARAM_CODE).map { it.paramValue }
+        logger().info(">>>>> cachedInvalidLinks: $cachedInvalidLinks")
+    }
 
-        return invalidLinks.contains(link)
+    fun isInvalidLink(link: String): Boolean {
+        return cachedInvalidLinks.contains(link)
     }
 }

--- a/blink-api/src/main/kotlin/com/jordyma/blink/feed/service/FeedSummarizeServiceImpl.kt
+++ b/blink-api/src/main/kotlin/com/jordyma/blink/feed/service/FeedSummarizeServiceImpl.kt
@@ -14,6 +14,7 @@ import com.jordyma.blink.keyword.service.KeywordService
 import com.jordyma.blink.logger
 import com.jordyma.blink.recommend.Recommend
 import com.jordyma.blink.recommend.RecommendRepository
+import jakarta.annotation.PostConstruct
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -102,6 +103,7 @@ class FeedSummarizeServiceImpl(
         const val SUMMARY_COMPLETED = "링크 요약이 완료되었어요."
     }
 
+    @PostConstruct // DB 데이터 메모리에 미리 로드해 캐싱
     fun isInvalidLink(link: String): Boolean {
         val invalidLinks = commonParamRepository.findByParamCode(EXCEPTION_LINK_PARAM_CODE)
             .map { it.paramValue }

--- a/blink-api/src/main/kotlin/com/jordyma/blink/folder/service/FolderServiceImpl.kt
+++ b/blink-api/src/main/kotlin/com/jordyma/blink/folder/service/FolderServiceImpl.kt
@@ -217,7 +217,7 @@ class FolderServiceImpl(
         return folder
     }
 
-    override fun getFailed(userId: Long): Folder? {
+    override fun getFailed(userId: Long): Folder {
         val user = userRepository.findById(userId).orElseThrow {
             ApplicationException(ErrorCode.USER_NOT_FOUND, "유저를 찾을 수 없습니다.")
         }

--- a/blink-core/src/main/kotlin/com.jordyma.blink/feed/domain/Feed.kt
+++ b/blink-core/src/main/kotlin/com.jordyma.blink/feed/domain/Feed.kt
@@ -91,6 +91,12 @@ class Feed(
         this.folder = folder
     }
 
+    fun update(folder: Folder, status: Status){
+        this.folder = folder
+        this.status = status
+    }
+
+
     fun updateSummarizedContent(summary: String, title: String, brunch: Source) {
         this.summary = summary
         this.title = title

--- a/blink-core/src/main/kotlin/com.jordyma.blink/folder/domain/service/FolderService.kt
+++ b/blink-core/src/main/kotlin/com.jordyma.blink/folder/domain/service/FolderService.kt
@@ -23,7 +23,7 @@ interface FolderService {
 
     fun getUnclassified(userId: Long): Folder
 
-    fun getFailed(userId: Long): Folder?
+    fun getFailed(userId: Long): Folder
 
     fun getFolderById(folderId: Long): Folder
 }

--- a/blink-core/src/main/kotlin/com/jordyma/blink/common/system/CommonParameter.kt
+++ b/blink-core/src/main/kotlin/com/jordyma/blink/common/system/CommonParameter.kt
@@ -1,0 +1,29 @@
+package com.jordyma.blink.common.system
+
+import jakarta.persistence.*
+import java.time.LocalDate
+
+@Entity
+@Table(
+    name = "common_parameter",
+    uniqueConstraints = [UniqueConstraint(columnNames = ["param_code", "param_value"])]
+)
+class CommonParameter(
+    @Column(name = "param_code", length = 50, nullable = false)
+    val paramCode: String,
+
+    @Column(name = "param_value", nullable = false)
+    val paramValue: String,
+
+    @Column(name = "valid_start_date")
+    val validStartDate: LocalDate? = null,
+
+    @Column(name = "valid_end_date")
+    val validEndDate: LocalDate? = null
+) {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0
+
+    protected constructor() : this("", "") // JPA 기본 생성자를 위해
+}

--- a/blink-core/src/main/kotlin/com/jordyma/blink/common/system/CommonParameterCode.kt
+++ b/blink-core/src/main/kotlin/com/jordyma/blink/common/system/CommonParameterCode.kt
@@ -1,6 +1,6 @@
 package com.jordyma.blink.common.system
 
 object CommonParameterCode {
-    const val EXCEPTION_LINK_PARAM_CODE = "EXCEPTION_LINK"
+    const val EXCEPTION_LINK_PARAM_CODE = "EXCEPT_PLATFORM_LINK"
     // 추가적으로 공통적으로 관리할 키들을 여기서 정의 가능
 }

--- a/blink-core/src/main/kotlin/com/jordyma/blink/common/system/CommonParameterCode.kt
+++ b/blink-core/src/main/kotlin/com/jordyma/blink/common/system/CommonParameterCode.kt
@@ -1,0 +1,6 @@
+package com.jordyma.blink.common.system
+
+object CommonParameterCode {
+    const val EXCEPTION_LINK_PARAM_CODE = "EXCEPTION_LINK"
+    // 추가적으로 공통적으로 관리할 키들을 여기서 정의 가능
+}

--- a/blink-core/src/main/kotlin/com/jordyma/blink/common/system/CommonParameterRepository.kt
+++ b/blink-core/src/main/kotlin/com/jordyma/blink/common/system/CommonParameterRepository.kt
@@ -1,0 +1,7 @@
+package com.jordyma.blink.common.system
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface CommonParameterRepository : JpaRepository<CommonParameter, Long> {
+    fun findByParamCode(paramCode: String): List<CommonParameter>
+}

--- a/blink-worker/src/main/kotlin/com/jordyma/blink/folder/service/FolderService.kt
+++ b/blink-worker/src/main/kotlin/com/jordyma/blink/folder/service/FolderService.kt
@@ -44,7 +44,7 @@ class FolderService(
         }
 
         // 요약 실패 폴더 찾기
-        var folder = folderRepository.findFailed(user, "FAILED")
+        var folder = folderRepository.findFailed(user, "요약실패")
         if(folder == null){     // 없으면 생성
             val request = CreateFolderRequestDto(
                 name = "요약실패"


### PR DESCRIPTION
## 1. 예외 링크 기능 추가
- 예외 링크들을 공통 파라미터 테이블에서 관리하도록 테이블 생성 
   CommonParameter 테이블 - EXCEPT_PLATFORM_LINK
- 예외 링크 여부 체크하는 함수 구현
- @PostConstruct 예외 링크 데이터 미리 캐싱

## 2. 요약 실패 처리 로직 수정
- 요약 실패 폴더 찾기 함수 (getFailed) 수정
- 실패 폴더 내에 실패 피드를 저장할 수 있도록 createFeedFolder 재활용

