### PR TITLE
feat: StatsStore 영속화

### DIFF
--- a/blink-api/src/main/kotlin/com/jordyma/blink/infra/stats/StatsStore.kt
+++ b/blink-api/src/main/kotlin/com/jordyma/blink/infra/stats/StatsStore.kt
@@ -1,17 +1,53 @@
 package com.jordyma.blink.infra.stats
 
+import com.jordyma.blink.logger
+import com.jordyma.blink.stats.UserStatisticRepository
+import jakarta.annotation.PostConstruct
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
 
 @Component
-class StatsStore {
+class StatsStore (
+    private val userStatisticRepository: UserStatisticRepository,
+){
     private val linkViewCounts = ConcurrentHashMap<String, AtomicLong>()
     private val dailyActiveUsers = ConcurrentHashMap<String, ConcurrentHashMap.KeySetView<Long, Boolean>>()
+
+    @PostConstruct
+    fun initializeFromDatabase() {
+        try {
+            val today = LocalDateTime.now()
+            val todayStr = LocalDate.now().format(DateTimeFormatter.ISO_DATE)
+
+            // 링크 조회수
+            val todayLinkViews = userStatisticRepository.findByTypeAndDate("LINK_VIEW", today)
+            if (todayLinkViews != null) {
+                linkViewCounts[todayStr] = AtomicLong(todayLinkViews.count)
+            }
+
+            // 활성 사용자 수
+            val todayActiveUsers = userStatisticRepository.findByTypeAndDate("ACTIVE_USER", today)
+            if (todayActiveUsers != null) {
+                // 일단은 더미 데이터로 count만 채우기
+                val userSet = ConcurrentHashMap.newKeySet<Long>()
+                repeat(todayActiveUsers.count.toInt()) { index ->
+                    userSet.add(-(index + 1).toLong())
+                }
+                dailyActiveUsers[todayStr] = userSet
+            }
+
+            logger().info("StatsStore initialized from database successfully")
+        } catch (e: Exception) {
+            logger().error("Failed to initialize StatsStore from database", e.message)
+        }
+    }
+
 
     // 링크 조회수 count
     fun countLinkView(date: String): Long {

--- a/blink-batch/src/main/kotlin/com/jordyma/blink/scheduler/StatsUpsertScheduler.kt
+++ b/blink-batch/src/main/kotlin/com/jordyma/blink/scheduler/StatsUpsertScheduler.kt
@@ -1,0 +1,63 @@
+package com.jordyma.blink.scheduler
+
+import com.jordyma.blink.infra.stats.StatsStore
+import com.jordyma.blink.logger
+import com.jordyma.blink.stats.UserStatistic
+import com.jordyma.blink.stats.UserStatisticRepository
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+
+@Component
+class StatsUpsertScheduler(
+    private val statsStore: StatsStore,
+    private val userStatisticRepository: UserStatisticRepository,
+) {
+
+    @Scheduled(cron = "0 59 * * * *")
+    @Transactional
+    fun upsertHourlyStats() {
+        try {
+            val today = LocalDate.now().format(DateTimeFormatter.ISO_DATE)
+            val now = LocalDateTime.now()
+
+            // 링크 조회수 upsert
+            val linkViewCount = statsStore.getLinkViewCount(today)
+            if (linkViewCount > 0) {
+                upsertUserStatistic(linkView, linkViewCount, now)
+            }
+
+            // 활성 사용자 수 upsert
+            val activeUserCount = statsStore.getActiveUserCount(today)
+            if (activeUserCount > 0) {
+                upsertUserStatistic(activeUser, activeUserCount, now)
+            }
+        } catch (e: Exception) {
+            logger().error("Failed to upsert stats", e.message)
+        }
+    }
+
+    private fun upsertUserStatistic(type: String, count: Long, dateTime: LocalDateTime) {
+        val existingStat = userStatisticRepository.findByTypeAndDate(type, dateTime)
+
+        if (existingStat != null) {
+            existingStat.updateCount(count)
+            userStatisticRepository.save(existingStat)
+        } else {
+            val newStat = UserStatistic(
+                type = type,
+                count = count
+            )
+            userStatisticRepository.save(newStat)
+        }
+    }
+
+    companion object{
+        const val activeUser= "ACTIVE_USER"
+        const val linkView = "LINK_VIEW"
+    }
+}

--- a/blink-core/src/main/kotlin/com.jordyma.blink/stats/UserStatistic.kt
+++ b/blink-core/src/main/kotlin/com.jordyma.blink/stats/UserStatistic.kt
@@ -1,0 +1,23 @@
+package com.jordyma.blink.stats
+
+import com.jordyma.blink.common.BaseTimeEntity
+import jakarta.persistence.*
+
+@Entity
+class UserStatistic(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    val id: Long? = null,
+
+    val type: String,
+
+    var count: Long,
+
+    ) : BaseTimeEntity() {
+
+    fun updateCount(count: Long){
+        this.count = count
+    }
+}

--- a/blink-core/src/main/kotlin/com.jordyma.blink/stats/UserStatisticRepository.kt
+++ b/blink-core/src/main/kotlin/com.jordyma.blink/stats/UserStatisticRepository.kt
@@ -1,0 +1,12 @@
+package com.jordyma.blink.stats
+
+import io.lettuce.core.dynamic.annotation.Param
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import java.time.LocalDateTime
+
+interface UserStatisticRepository : JpaRepository<UserStatistic, Long> {
+
+    @Query("SELECT u FROM UserStatistic u WHERE u.type = :type AND DATE(u.createdAt) = DATE(:date)")
+    fun findByTypeAndDate(@Param("type") type: String, @Param("date") date: LocalDateTime): UserStatistic?
+}


### PR DESCRIPTION
* 링크 조회수, 활성 유저수 1시간에 한 번씩 DB 저장 (StatsUpsertScheduler)
* 서버 재시작시 DB에서 로드됨 (StatsStore.initializeFromDatabase())